### PR TITLE
Saving articles/44

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,9 @@ gem 'rails', '5.2.8.1'
 # Use Puma as the app server
 gem 'puma'
 
+# Library mocha for stubbing in cucumber
+gem 'mocha'
+
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 # Note: Pin the webpacker version to the same version used in package.json
 gem 'webpacker', '5.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -282,6 +282,8 @@ GEM
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.3)
+    mocha (2.1.0)
+      ruby2_keywords (>= 0.0.5)
     msgpack (1.4.2)
     multi_json (1.15.0)
     multi_test (0.1.2)
@@ -536,6 +538,7 @@ DEPENDENCIES
   haml-lint
   haml-rails
   listen (>= 3.0.5, < 3.2)
+  mocha
   news-api
   omniauth!
   omniauth-github

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -36,6 +36,18 @@ class MyNewsItemsController < SessionController
   end
 
   def save
+    article_id = params['article_id']
+    selected_article = params['articles'][article_id]
+    news_item = NewsItem.create!(
+      {
+        representative: @representative,
+        title:          selected_article['title'],
+        description:    selected_article['link'],
+        link:           selected_article['description']
+      }
+    )
+    news_item.save!
+    binding.pry
   end
 
   def edit; end

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -50,6 +50,7 @@ class MyNewsItemsController < SessionController
         title:          selected_article['title'],
         description:    selected_article['description'],
         link:           selected_article['link'],
+        issue:          selected_article['issue'],
         rating:         rating
       }
     )

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -49,7 +49,8 @@ class MyNewsItemsController < SessionController
         representative: @representative,
         title:          selected_article['title'],
         description:    selected_article['description'],
-        link:           selected_article['link']
+        link:           selected_article['link'],
+        rating: rating
       }
     )
     news_item.save!

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -32,8 +32,8 @@ class MyNewsItemsController < SessionController
     # end
     # @articles = []
     @articles = NewsItem.query_news_api(@rep_name, @issue)
-    if @articles.length == 0
-      flash[:notice] = "No articles were found."
+    if @articles.length.zero?
+      flash[:notice] = 'No articles were found.'
       redirect_to representative_new_my_news_item_path(@representative)
     end
 
@@ -50,12 +50,12 @@ class MyNewsItemsController < SessionController
         title:          selected_article['title'],
         description:    selected_article['description'],
         link:           selected_article['link'],
-        rating: rating
+        rating:         rating
       }
     )
     news_item.save!
     # binding.pry
-    flash[:notice] = "Article was successfully saved."
+    flash[:notice] = 'Article was successfully saved.'
     redirect_to representative_news_items_path(@representative.id)
   end
 
@@ -99,11 +99,11 @@ class MyNewsItemsController < SessionController
   end
 
   def set_issues_list
-    @issues_list = ["Free Speech", "Immigration", "Terrorism", "Social Security and
-    Medicare", "Abortion", "Student Loans", "Gun Control", "Unemployment",
-    "Climate Change", "Homelessness", "Racism", "Tax Reform", "Net
-    Neutrality", "Religious Freedom", "Border Security", "Minimum Wage",
-    "Equal Pay"]
+    @issues_list = ['Free Speech', 'Immigration', 'Terrorism', "Social Security and
+    Medicare", 'Abortion', 'Student Loans', 'Gun Control', 'Unemployment',
+                    'Climate Change', 'Homelessness', 'Racism', 'Tax Reform', "Net
+    Neutrality", 'Religious Freedom', 'Border Security', 'Minimum Wage',
+                    'Equal Pay']
   end
 
   def set_news_item

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -30,7 +30,12 @@ class MyNewsItemsController < SessionController
       @articles[i] = article
     end
 
+    # @articles = []
     # @articles = NewsItem.query_news_api(@rep_name, @issue)
+    if @articles.length == 0
+      flash[:notice] = "No articles were found."
+      redirect_to representative_new_my_news_item_path(@representative)
+    end
 
     # binding.pry
   end
@@ -38,16 +43,19 @@ class MyNewsItemsController < SessionController
   def save
     article_id = params['article_id']
     selected_article = params['articles'][article_id]
+    rating = params['rating']
     news_item = NewsItem.create!(
       {
         representative: @representative,
         title:          selected_article['title'],
-        description:    selected_article['link'],
-        link:           selected_article['description']
+        description:    selected_article['description'],
+        link:           selected_article['link']
       }
     )
     news_item.save!
-    binding.pry
+    # binding.pry
+    flash[:notice] = "Article was successfully saved."
+    redirect_to representative_news_items_path(@representative.id)
   end
 
   def edit; end

--- a/app/controllers/my_news_items_controller.rb
+++ b/app/controllers/my_news_items_controller.rb
@@ -20,18 +20,18 @@ class MyNewsItemsController < SessionController
     @rep_name = @representative.name
     @issue = params[:news_item][:issue]
     params[:id] = @representative.id
-    # stub it
-    @articles = []
-    5.times do |i|
-      article = {}
-      article['title'] = "test_title#{i}"
-      article['link'] = "test_link#{i}"
-      article['text'] = "test_description#{i}"
-      @articles[i] = article
-    end
 
+    # # stub it
     # @articles = []
-    # @articles = NewsItem.query_news_api(@rep_name, @issue)
+    # 5.times do |i|
+    #   article = {}
+    #   article['title'] = "test_title#{i}"
+    #   article['link'] = "test_link#{i}"
+    #   article['text'] = "test_description#{i}"
+    #   @articles[i] = article
+    # end
+    # @articles = []
+    @articles = NewsItem.query_news_api(@rep_name, @issue)
     if @articles.length == 0
       flash[:notice] = "No articles were found."
       redirect_to representative_new_my_news_item_path(@representative)

--- a/app/controllers/representatives_controller.rb
+++ b/app/controllers/representatives_controller.rb
@@ -7,7 +7,7 @@ class RepresentativesController < ApplicationController
 
   def show
     @representative = Representative.find(params[:id])
-    binding.pry
+    # binding.pry
     @ocdid_state = nil
     state = @representative.ocdid.match(/state:(\w{2})/)
     @ocdid_state = state.captures[0].upcase unless state.nil?

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -44,5 +44,4 @@ class NewsItem < ApplicationRecord
       "from=#{Date.today - 30.days}&" \
       'sort_by=relevancy&'
   end
-  
 end

--- a/app/views/my_news_items/search.html.erb
+++ b/app/views/my_news_items/search.html.erb
@@ -7,7 +7,7 @@
       
       <div class="row">
         <div class="col">
-          <h4 class="heading">Representative: 
+          <h4 class="heading" id="rep-heading">Representative: 
             <a href="<%= representative_path(@representative.id) %>"> <%= @representative.name %> 
             </a>
           </h4>
@@ -15,7 +15,7 @@
       </div>
       <div class="row">
         <div class="col">
-          <h4 class="heading">Issue: <%= @issue %></h4>
+          <h4 class="heading" id="issue-heading">Issue: <%= @issue %></h4>
         </div>
       </div>
 

--- a/app/views/my_news_items/search.html.erb
+++ b/app/views/my_news_items/search.html.erb
@@ -34,6 +34,7 @@
               <%= f.hidden_field "articles[#{index}][title]", value: article['title'] %>
               <%= f.hidden_field "articles[#{index}][link]", value: article['link'] %>
               <%= f.hidden_field "articles[#{index}][description]", value: article['text'] %>
+              <%= f.hidden_field "articles[#{index}][issue]", value: @issue %>
             </label>
           </div>
         </div>

--- a/app/views/news_items/index.html.haml
+++ b/app/views/news_items/index.html.haml
@@ -22,6 +22,7 @@
                             %th Description
                             %th Posted
                             %th{ colspan: 3 } Links
+                            %th Rating
                     %tbody
                         - @news_items.each_with_index do |item, index|
                             %tr
@@ -46,3 +47,5 @@
                                     = link_to representative_news_item_path(item.representative.id, item.id),
                                     method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' do
                                         %i.fas.fa-trash &nbsp;Delete
+                                %td= item.rating
+								

--- a/app/views/news_items/index.html.haml
+++ b/app/views/news_items/index.html.haml
@@ -21,8 +21,8 @@
                             %th Name
                             %th Description
                             %th Posted
-                            %th{ colspan: 3 } Links
                             %th Rating
+                            %th{ colspan: 3 } Links
                     %tbody
                         - @news_items.each_with_index do |item, index|
                             %tr
@@ -35,6 +35,7 @@
                                 %td= item.description
                                 %td
                                     %time.timeago{ datetime: item.created_at.iso8601 }
+                                %td= item.rating
                                 %td
                                     = link_to representative_news_item_path(item.representative.id, item.id),
                                     class: 'btn btn-info article_link' do
@@ -47,5 +48,3 @@
                                     = link_to representative_news_item_path(item.representative.id, item.id),
                                     method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-danger' do
                                         %i.fas.fa-trash &nbsp;Delete
-                                %td= item.rating
-								

--- a/db/migrate/20231129050050_add_rating_to_news_article.rb
+++ b/db/migrate/20231129050050_add_rating_to_news_article.rb
@@ -1,0 +1,5 @@
+class AddRatingToNewsArticle < ActiveRecord::Migration[5.2]
+  def change
+    add_column :news_items, :rating, :integer
+  end
+end

--- a/db/migrate/20231129050050_add_rating_to_news_article.rb
+++ b/db/migrate/20231129050050_add_rating_to_news_article.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRatingToNewsArticle < ActiveRecord::Migration[5.2]
   def change
     add_column :news_items, :rating, :integer

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_11_26_230459) do
+ActiveRecord::Schema.define(version: 2023_11_29_050050) do
 
   create_table "counties", force: :cascade do |t|
     t.string "name", null: false
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 2023_11_26_230459) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "issue"
+    t.integer "rating"
     t.index ["representative_id"], name: "index_news_items_on_representative_id"
   end
 

--- a/features/my_news_items_second_page.feature
+++ b/features/my_news_items_second_page.feature
@@ -1,0 +1,19 @@
+Feature: News Items second page search results
+  Scenario:
+    Given that I am on news items first page for Joseph R. Biden
+    When I select representative as Alex Padilla
+    When I select issue as Immigration
+    When I hit the Search button
+    Then I should be on the second page for news item search
+    Then I should have Alex Padilla profile link
+    Then I should see issue listed as Immigration
+    Then I should see an article with title Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19
+    Then I should see an article with link https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/
+    Then I should see a description with The new order affects 19 California counties with a surging number of coronavirus cases
+    Then I should see a selection for Rating for 1
+    Then I should see a selection for Rating for 2
+    Then I should see a selection for Rating for 5
+    Then I should see a selection for Rating for 10
+    Then I should see a button named View News Articles
+    When I click for the View News Articles button
+    Then I should see Alex Padilla articles list

--- a/features/my_news_items_second_page.feature
+++ b/features/my_news_items_second_page.feature
@@ -4,16 +4,16 @@ Feature: News Items second page search results
     When I select representative as Alex Padilla
     When I select issue as Immigration
     When I hit the Search button
-    Then I should be on the second page for news item search
+    Then I should now be on the second page for news item search
     Then I should have Alex Padilla profile link
     Then I should see issue listed as Immigration
-    Then I should see an article with title Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19
-    Then I should see an article with link https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/
-    Then I should see a description with The new order affects 19 California counties with a surging number of coronavirus cases
+    Then I should see an article with title Guerrero: Biden can win on immigration by outmaneuvering the xenophobic wing of the GOP
+    Then I should see an article with link https://www.latimes.com/opinion/story/2023-11-06/biden-immigration-parole-republicans-work-permits
+    Then I should see a description with The president could start with work permits for some immigrants in California and other states, then create a parole program for Dreamers and undocumented relatives of U.S. citizens.
     Then I should see a selection for Rating for 1
     Then I should see a selection for Rating for 2
     Then I should see a selection for Rating for 5
     Then I should see a selection for Rating for 10
     Then I should see a button named View News Articles
-    When I click for the View News Articles button
+    When I follow "View News Articles"
     Then I should see Alex Padilla articles list

--- a/features/representatives_linking.feature
+++ b/features/representatives_linking.feature
@@ -7,4 +7,4 @@ Scenario:
   Given I am on the representatives search page
   When I search California 
   When I follow "Joseph R. Biden"
-  Then I should be on representatives/2
+  Then I should be on "representatives/2"

--- a/features/step_definitions/my_news_items_second_page.steps.rb
+++ b/features/step_definitions/my_news_items_second_page.steps.rb
@@ -43,38 +43,38 @@ When /I select issue as (.*)/ do |issue|
 end
 
 When /I hit the Search button/ do 
-  stubbed_articles = [
-    { 'title' => 'Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19', 
-      'link' => 'https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/', 
-      'text' => 'The new order affects 19 California counties with a surging number of coronavirus cases' },
-    { 'title' => 'Rethinking Americas Immigration Policy', 
-    'link' => 'https://www.migrationpolicy.org/programs/us-immigration-policy-program/rethinking-us-immigration?gclid=CjwKCAiAvJarBhA1EiwAGgZl0M9mZKoNCeITuUhBGGBgwdm_zrosXtq_CuukHUA85NEeSRcnafGyxhoCqSEQAvD_BwE', 
-    'text' => 'Building a reponsive and affective immigration system' },
-  ]
+  # stubbed_articles = [
+  #   { 'title' => 'Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19', 
+  #     'link' => 'https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/', 
+  #     'text' => 'The new order affects 19 California counties with a surging number of coronavirus cases' },
+  #   { 'title' => 'Rethinking Americas Immigration Policy', 
+  #   'link' => 'https://www.migrationpolicy.org/programs/us-immigration-policy-program/rethinking-us-immigration?gclid=CjwKCAiAvJarBhA1EiwAGgZl0M9mZKoNCeITuUhBGGBgwdm_zrosXtq_CuukHUA85NEeSRcnafGyxhoCqSEQAvD_BwE', 
+  #   'text' => 'Building a reponsive and affective immigration system' },
+  # ]
   # inst = NewsItem.new
   # NewsItem.any_instance.stubs(:query_news_api).returns(stubbed_articles)
   # allow(NewsItem).to receive(:query_news_api).and_return(stubbed_articles)
   # allow(inst).to receive(:query_news_api).and_return(stubbed_articles)
-  NewsItem.stubs(:query_news_api).returns(stubbed_articles)
+  # NewsItem.stubs(:query_news_api).returns(stubbed_articles)
   click_button('Search')
 end
 
-Then /I should be on the second page for news item search/ do
-  exptec_page_path = representative_search_my_news_item_path(@rep)
+Then /I should now be on the second page for news item search/ do
+  expected_page_path = representative_search_my_news_item_path(@rep)
   expect(page).to have_current_path(expected_page_path)
 end
 
 Then /I should have (.*) profile link/ do |name| 
   @test_rep = Representative.where(name: name).first
   id = @test_rep.id
-  within('.heading') do
+  within('#rep-heading') do
     expect(page).to have_content("Representative: #{name}")
     expect(page).to have_link(name, href: "/representatives/#{id}")
   end
 end
 
 Then /I should see issue listed as (.*)/ do |issue|
-  within('.heading') do
+  within('#issue-heading') do
     expect(page).to have_content("Issue: #{issue}")
   end
 end
@@ -107,6 +107,6 @@ end
 
 Then /I should see (.*) articles list/ do |name|
   @test_rep = Representative.where(name: name).first
-  exptec_page_path = representative_news_items_path(@test_rep)
+  expected_page_path = representative_news_items_path(@test_rep)
   expect(page).to have_current_path(expected_page_path)
 end

--- a/features/step_definitions/my_news_items_second_page.steps.rb
+++ b/features/step_definitions/my_news_items_second_page.steps.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'mocha'
+
+Given /that I am on news items first page for (.*)/ do |name|
+  Representative.create!({ name: name, ocdid: 1,
+    title: 'President of the United States', photo: '',
+    address: '1600 Pennsylvania Avenue Northwest', party: 'Democrat' })
+  Representative.create!({ name: 'Alex Padilla', ocdid: 10,
+    title: 'President of the United States', photo: '',
+    address: '1600 Pennsylvania Avenue Northwest', party: 'Democrat' })
+
+  @rep = Representative.where(name: name).first
+  visit representative_new_my_news_item_path(@rep)
+  find(:css, 'button.btn.btn-lg.btn-google.btn-block.text-uppercase.bg-danger.text-white',
+       text: 'Sign in with Google').click
+  visit representative_new_my_news_item_path(@rep)
+  # expect(page).to have_current_path('representatives/1/representatives/1/my_news_item/new')
+  
+end
+
+When /I select representative as (.*)/ do |name|
+  # puts page.body
+  # select(name, :from => '.form-control.#news_item_representative_id')
+  # select_box = find('#news_item_representative_id.form-control', visible: :all, wait: 10)
+  # select name, from: select_box
+  # select name, :from => '#news_item_representative_id'
+  
+  # select_script = "document.querySelector('#news_item_representative_id').value = '#{name}';"
+  # page.execute_script(select_script)
+
+  # select_box = find('#news_item_representative_id.form-control', visible: :all, wait: 10)
+  # select name, from: select_box
+
+  # options = find('#news_item_representative_id').all('option').map(&:text)
+  # expect(options).to include(name)
+  
+  select(name, :from => 'news_item_representative_id')
+end
+
+When /I select issue as (.*)/ do |issue|
+  select(issue, :from => 'news_item_issue')
+end
+
+When /I hit the Search button/ do 
+  stubbed_articles = [
+    { 'title' => 'Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19', 
+      'link' => 'https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/', 
+      'text' => 'The new order affects 19 California counties with a surging number of coronavirus cases' },
+    { 'title' => 'Rethinking Americas Immigration Policy', 
+    'link' => 'https://www.migrationpolicy.org/programs/us-immigration-policy-program/rethinking-us-immigration?gclid=CjwKCAiAvJarBhA1EiwAGgZl0M9mZKoNCeITuUhBGGBgwdm_zrosXtq_CuukHUA85NEeSRcnafGyxhoCqSEQAvD_BwE', 
+    'text' => 'Building a reponsive and affective immigration system' },
+  ]
+  # inst = NewsItem.new
+  # NewsItem.any_instance.stubs(:query_news_api).returns(stubbed_articles)
+  # allow(NewsItem).to receive(:query_news_api).and_return(stubbed_articles)
+  # allow(inst).to receive(:query_news_api).and_return(stubbed_articles)
+  NewsItem.stubs(:query_news_api).returns(stubbed_articles)
+  click_button('Search')
+end
+
+Then /I should be on the second page for news item search/ do
+  exptec_page_path = representative_search_my_news_item_path(@rep)
+  expect(page).to have_current_path(expected_page_path)
+end
+
+Then /I should have (.*) profile link/ do |name| 
+  @test_rep = Representative.where(name: name).first
+  id = @test_rep.id
+  within('.heading') do
+    expect(page).to have_content("Representative: #{name}")
+    expect(page).to have_link(name, href: "/representatives/#{id}")
+  end
+end
+
+Then /I should see issue listed as (.*)/ do |issue|
+  within('.heading') do
+    expect(page).to have_content("Issue: #{issue}")
+  end
+end
+
+Then /I should see an article with title (.*)/ do |title|
+  expect(page).to have_content("Title: #{title}")
+end
+
+Then /I should see an article with link (.*)/ do |link|
+  expect(page).to have_link(link, href: link)
+end
+
+Then /I should see a description with (.*)/ do |description|
+  expect(page).to have_content("Description: #{description}")
+end
+
+Then /I should see a selection for Rating for (.*)/ do |selection|
+  expect(page).to have_content("Rating:")
+  options = find('#rating').all('option').map(&:text)
+  expect(options).to include(selection)
+end
+
+Then /I should see a button named (.*)/ do |button_name|
+  expect(page).to have_selector('a.btn.btn-secondary', text: button_name)
+end
+
+When /I click for the (.*) button/ do |button_name|
+  click_button(button_name)
+end
+
+Then /I should see (.*) articles list/ do |name|
+  @test_rep = Representative.where(name: name).first
+  exptec_page_path = representative_news_items_path(@test_rep)
+  expect(page).to have_current_path(expected_page_path)
+end

--- a/features/step_definitions/my_news_items_second_page.steps.rb
+++ b/features/step_definitions/my_news_items_second_page.steps.rb
@@ -16,7 +16,6 @@ Given /that I am on news items first page for (.*)/ do |name|
        text: 'Sign in with Google').click
   visit representative_new_my_news_item_path(@rep)
   # expect(page).to have_current_path('representatives/1/representatives/1/my_news_item/new')
-  
 end
 
 When /I select representative as (.*)/ do |name|
@@ -25,7 +24,7 @@ When /I select representative as (.*)/ do |name|
   # select_box = find('#news_item_representative_id.form-control', visible: :all, wait: 10)
   # select name, from: select_box
   # select name, :from => '#news_item_representative_id'
-  
+
   # select_script = "document.querySelector('#news_item_representative_id').value = '#{name}';"
   # page.execute_script(select_script)
 
@@ -34,21 +33,21 @@ When /I select representative as (.*)/ do |name|
 
   # options = find('#news_item_representative_id').all('option').map(&:text)
   # expect(options).to include(name)
-  
-  select(name, :from => 'news_item_representative_id')
+
+  select(name, from: 'news_item_representative_id')
 end
 
 When /I select issue as (.*)/ do |issue|
-  select(issue, :from => 'news_item_issue')
+  select(issue, from: 'news_item_issue')
 end
 
-When /I hit the Search button/ do 
+When /I hit the Search button/ do
   # stubbed_articles = [
-  #   { 'title' => 'Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19', 
-  #     'link' => 'https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/', 
+  #   { 'title' => 'Newsom Orders Second Shutdown of Restaurants and Indoor Businesses amid COVID-19',
+  #     'link' => 'https://people.com/human-interest/california-gov-gavin-newsom-orders-second-shutdown-of-restaurants-and-indoor-businesses-amid-covid-19/',
   #     'text' => 'The new order affects 19 California counties with a surging number of coronavirus cases' },
-  #   { 'title' => 'Rethinking Americas Immigration Policy', 
-  #   'link' => 'https://www.migrationpolicy.org/programs/us-immigration-policy-program/rethinking-us-immigration?gclid=CjwKCAiAvJarBhA1EiwAGgZl0M9mZKoNCeITuUhBGGBgwdm_zrosXtq_CuukHUA85NEeSRcnafGyxhoCqSEQAvD_BwE', 
+  #   { 'title' => 'Rethinking Americas Immigration Policy',
+  #   'link' => 'https://www.migrationpolicy.org/programs/us-immigration-policy-program/rethinking-us-immigration?gclid=CjwKCAiAvJarBhA1EiwAGgZl0M9mZKoNCeITuUhBGGBgwdm_zrosXtq_CuukHUA85NEeSRcnafGyxhoCqSEQAvD_BwE',
   #   'text' => 'Building a reponsive and affective immigration system' },
   # ]
   # inst = NewsItem.new
@@ -64,7 +63,7 @@ Then /I should now be on the second page for news item search/ do
   expect(page).to have_current_path(expected_page_path)
 end
 
-Then /I should have (.*) profile link/ do |name| 
+Then /I should have (.*) profile link/ do |name|
   @test_rep = Representative.where(name: name).first
   id = @test_rep.id
   within('#rep-heading') do
@@ -92,7 +91,7 @@ Then /I should see a description with (.*)/ do |description|
 end
 
 Then /I should see a selection for Rating for (.*)/ do |selection|
-  expect(page).to have_content("Rating:")
+  expect(page).to have_content('Rating:')
   options = find('#rating').all('option').map(&:text)
   expect(options).to include(selection)
 end

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -227,7 +227,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should not be checked$/ do |label
   end
 end
  
-Then /^(?:|I )should be on (.+)$/ do |page_name|
+Then /^(?:|I )should be on "(.+)"$/ do |page_name|
   current_path = URI.parse(current_url).path
   if current_path.respond_to? :should
     current_path.should == path_to(page_name)


### PR DESCRIPTION
- added functionality to save news articles onto a representative's news articles page
- wrote a cucumber test to ensure that the process of searching for a representative + issue combo, and selecting + saving an article works
- changed the news_item model to have a 'rating' column; also added functionality to display a news article's ratings on a representative's articles page